### PR TITLE
Add docker-compose to initial laptop setup bash setup script

### DIFF
--- a/mac
+++ b/mac
@@ -153,6 +153,7 @@ brew "redis"
 # Docker
 cask "docker"
 cask "vagrant"
+brew "docker-compose"
 
 # GitHub
 brew "hub"


### PR DESCRIPTION
In the initial setup for onboarding developers, we have the ability to allow new devs to utilize docker-compose to get their development environment setup. However, we do not actually install docker-compose via the install script. This adds docker-compose so that is a viable option.